### PR TITLE
Code style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Ignore stuff for export
+/tests                  export-ignore
+/examples               export-ignore
+/img                    export-ignore
+/.gitattributes         export-ignore
+/.gitignore             export-ignore
+/.github                export-ignore
+/phpcs.xml              export-ignore
+/phpunit.xml            export-ignore
+/README.md              export-ignore

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "hlsxx/qrwatermark",
     "description": "A library to generate QR codes with watermarks.",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "type": "library",
     "autoload": {
         "psr-4": {
@@ -15,6 +15,6 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^8.4"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,17 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdb2dd4a0f60afcf0798f4456ec015dc",
+    "content-hash": "c865791a35de3be90db6f07e665283b4",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {
+        "php": "^8.4"
+    },
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/examples/custom.php
+++ b/examples/custom.php
@@ -7,17 +7,12 @@ use Hlsxx\QrWatermark\Configs\ImageConfigBuilder;
 use Hlsxx\QrWatermark\Configs\LogoConfigBuilder;
 
 // Custom image config
-$imageConfig = (new ImageConfigBuilder())
+$imageConfig = new ImageConfigBuilder()
   // ->colorGradient([255, 255, 255], [0, 0, 0]) // Custom gradient
-  ->color([72, 76, 137])
-  ->isAutoGradientEnabled()
-  ->build();
+  ->color([72, 76, 137])->isAutoGradientEnabled();
 
 // Custom logo config
-$logoConfig =  (new LogoConfigBuilder())
-  ->width(70)
-  ->height(70)
-  ->build();
+$logoConfig =  new LogoConfigBuilder()->width(70)->height(70);
 
 $qrw = (new QrWatermark("Hello from PHP custom"))
   ->logo("imgs/php_logo.png")
@@ -30,5 +25,3 @@ try {
 } catch (\Exception $e) {
   var_dump($e->getMessage());
 }
-
-?>

--- a/examples/custom.php
+++ b/examples/custom.php
@@ -14,7 +14,7 @@ $imageConfig = new ImageConfigBuilder()
 // Custom logo config
 $logoConfig =  new LogoConfigBuilder()->width(70)->height(70);
 
-$qrw = (new QrWatermark("Hello from PHP custom"))
+$qrw = new QrWatermark("Hello from PHP custom")
   ->logo("imgs/php_logo.png")
   ->logoConfig($logoConfig)
   ->imageConfig($imageConfig);

--- a/examples/default.php
+++ b/examples/default.php
@@ -6,5 +6,3 @@ use Hlsxx\QrWatermark\QrWatermark;
 
 $qrw = new QrWatermark("Hello from PHP");
 $qrw->saveAsImage("imgs/default.png");
-
-?>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset name="YAPF">
+    <description>The YAPF PHP coding standard.</description>
+    <file>src</file>
+    <exclude-pattern>vendor</exclude-pattern>
+    <exclude-pattern>docs</exclude-pattern>
+    <exclude-pattern>tests</exclude-pattern>
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php" />
+    <arg name="colors"/>
+    <arg name="parallel" value="80"/>
+    <!-- Show progress -->
+    <arg value="p"/>
+    <rule ref="PSR12"/>
+    <rule ref="Generic.Files.LineLength"/>
+    <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.WhiteSpace.ScopeIndent">
+        <properties>
+            <property name="indent" value="4"/>
+            <property name="tabIndent" value="true"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/src/Configs/ImageConfig.php
+++ b/src/Configs/ImageConfig.php
@@ -2,31 +2,14 @@
 
 namespace Hlsxx\QrWatermark\Configs;
 
-class ImageConfig {
-
-  public int $pixelSize;
-  public int $marginSize;
-  public array $color;
-  public ?array $colorsGradient;
-  public array $backgroundColor;
-  public bool $isAutoGradientEnabled;
-
+class ImageConfig
+{
   public function __construct(
-    int $pixelSize,
-    int $marginSize,
-    array $color,
-    ?array $colorsGradient,
-    array $backgroundColor,
-    bool $isAutoGradientEnabled
-  ) {
-    $this->pixelSize = $pixelSize;
-    $this->marginSize = $marginSize;
-    $this->color = $color;
-    $this->colorsGradient = $colorsGradient;
-    $this->backgroundColor = $backgroundColor;
-    $this->isAutoGradientEnabled = $isAutoGradientEnabled;
-  }
-
+    public int $pixelSize,
+    public int $marginSize,
+    public array $color,
+    public ?array $colorsGradient,
+    public array $backgroundColor,
+    public bool $isAutoGradientEnabled
+  ) {}
 }
-
-?>

--- a/src/Configs/ImageConfigBuilder.php
+++ b/src/Configs/ImageConfigBuilder.php
@@ -2,7 +2,8 @@
 
 namespace Hlsxx\QrWatermark\Configs;
 
-class ImageConfigBuilder {
+class ImageConfigBuilder
+{
 
   private int $_pixelSize = 10;
   private int $_marginSize = 1;
@@ -17,7 +18,8 @@ class ImageConfigBuilder {
    * @param int $size
    * @return ImageConfigBuilder
   */
-  public function pixelSize(int $size): ImageConfigBuilder {
+  public function pixelSize(int $size): ImageConfigBuilder
+  {
     $this->_pixelSize = $size;
     return $this;
   }
@@ -28,7 +30,8 @@ class ImageConfigBuilder {
    * @param int $size
    * @return ImageConfigBuilder
   */
-  public function marginSize(int $size): ImageConfigBuilder {
+  public function marginSize(int $size): ImageConfigBuilder
+  {
     $this->_marginSize = $size;
     return $this;
   }
@@ -39,7 +42,8 @@ class ImageConfigBuilder {
    * @param array $rgb Pixel color e.g. black ([255, 255, 255])
    * @return ImageConfigBuilder
   */
-  public function color(array $rgb): ImageConfigBuilder {
+  public function color(array $rgb): ImageConfigBuilder
+  {
     $this->_color = $rgb;
     return $this;
   }
@@ -54,7 +58,8 @@ class ImageConfigBuilder {
    *
    * @return ImageConfigBuilder
   */
-  public function colorGradient(array $startColorRgb, array $endColorRgb): ImageConfigBuilder {
+  public function colorGradient(array $startColorRgb, array $endColorRgb): ImageConfigBuilder
+  {
     $this->_colorsGradient = [$startColorRgb, $endColorRgb];
     return $this;
   }
@@ -65,7 +70,8 @@ class ImageConfigBuilder {
    * @param array $rgb Rgb color e.g., Black color ([0, 0, 0])
    * @return ImageConfigBuilder
   */
-  public function backgroundColor(array $rgb): ImageConfigBuilder {
+  public function backgroundColor(array $rgb): ImageConfigBuilder
+  {
     $this->_backgroundColor = $rgb;
     return $this;
   }
@@ -76,7 +82,8 @@ class ImageConfigBuilder {
    *
    * @return ImageConfigBuilder
   */
-  public function isAutoGradientEnabled(): ImageConfigBuilder {
+  public function isAutoGradientEnabled(): ImageConfigBuilder
+  {
     $this->_isAutoGradientEnabled = true;
     return $this;
   }
@@ -86,7 +93,8 @@ class ImageConfigBuilder {
    *
    * @return ImageConfig
   */
-  public function build() {
+  public function build()
+  {
     return new ImageConfig(
       $this->_pixelSize,
       $this->_marginSize,
@@ -96,7 +104,4 @@ class ImageConfigBuilder {
       $this->_isAutoGradientEnabled
     );
   }
-
 }
-
-?>

--- a/src/Configs/LogoConfig.php
+++ b/src/Configs/LogoConfig.php
@@ -2,19 +2,10 @@
 
 namespace Hlsxx\QrWatermark\Configs;
 
-class LogoConfig {
-
-  public int $width;
-  public int $height;
-
+class LogoConfig
+{
   public function __construct(
-    int $width,
-    int $height
-  ) {
-    $this->width = $width;
-    $this->height = $height;
-  }
-
+    public int $width,
+    public int $height
+  ) {}
 }
-
-?>

--- a/src/Configs/LogoConfigBuilder.php
+++ b/src/Configs/LogoConfigBuilder.php
@@ -2,7 +2,8 @@
 
 namespace Hlsxx\QrWatermark\Configs;
 
-class LogoConfigBuilder {
+class LogoConfigBuilder
+{
 
   private int $_width = 50;
   private int $_height = 50;
@@ -13,7 +14,8 @@ class LogoConfigBuilder {
    * @param int $size
    * @return LogoConfigBuilder
   */
-  public function width(int $size): LogoConfigBuilder {
+  public function width(int $size): LogoConfigBuilder
+  {
     $this->_width = $size;
     return $this;
   }
@@ -24,7 +26,8 @@ class LogoConfigBuilder {
    * @param int $size
    * @return LogoConfigBuilder
   */
-  public function height(int $size): LogoConfigBuilder {
+  public function height(int $size): LogoConfigBuilder
+  {
     $this->_height = $size;
     return $this;
   }
@@ -34,13 +37,11 @@ class LogoConfigBuilder {
    *
    * @return LogoConfig
   */
-  public function build() {
+  public function build()
+  {
     return new LogoConfig(
       $this->_width,
       $this->_height,
     );
   }
-
 }
-
-?>

--- a/src/QrWatermark.php
+++ b/src/QrWatermark.php
@@ -7,9 +7,8 @@ use Hlsxx\QrWatermark\Configs\ImageConfigBuilder;
 use Hlsxx\QrWatermark\Configs\LogoConfig;
 use Hlsxx\QrWatermark\Configs\LogoConfigBuilder;
 
-class QrWatermark {
-
-  private string $_text;
+class QrWatermark
+{
   private ?string $_logoPath = null;
   private ImageConfig $_imageConfig;
   private LogoConfig $_logoConfig;
@@ -18,13 +17,11 @@ class QrWatermark {
    * @param string $text QR code text
    */
   public function __construct(
-    string $text
+    private string $text
   ) {
-    $this->_text = $text;
-
     // Defaults
-    $this->_imageConfig = (new ImageConfigBuilder())->build();
-    $this->_logoConfig = (new LogoConfigBuilder())->build();
+    $this->_imageConfig = new ImageConfigBuilder()->build();
+    $this->_logoConfig = new LogoConfigBuilder()->build();
   }
 
   /*
@@ -33,7 +30,8 @@ class QrWatermark {
    * @param string $logoPath
    * @return QrWatermark
   */
-  public function logo(string $logoPath): QrWatermark {
+  public function logo(string $logoPath): QrWatermark
+  {
     $this->_logoPath = $logoPath;
     return $this;
   }
@@ -44,8 +42,13 @@ class QrWatermark {
    * @param ImageConfig $imageConfig
    * @return QrWatermark
   */
-  public function imageConfig(ImageConfig $imageConfig): QrWatermark {
-    $this->_imageConfig = $imageConfig;
+  public function imageConfig(ImageConfigBuilder|ImageConfig $imageConfig): QrWatermark
+  {
+    $worker = $imageConfig;
+    if ($imageConfig instanceof ImageConfigBuilder) {
+      $worker = $imageConfig->build();
+    }
+    $this->_imageConfig = $worker;
     return $this;
   }
 
@@ -55,8 +58,13 @@ class QrWatermark {
    * @param LogoConfig $logoConfig
    * @return QrWatermark
   */
-  public function logoConfig(LogoConfig $logoConfig): QrWatermark {
-    $this->_logoConfig = $logoConfig;
+  public function logoConfig(LogoConfigBuilder|LogoConfig $logoConfig): QrWatermark
+  {
+    $worker = $logoConfig;
+    if ($logoConfig instanceof LogoConfigBuilder) {
+      $worker = $logoConfig->build();
+    }
+    $this->_logoConfig = $worker;
     return $this;
   }
 
@@ -66,9 +74,10 @@ class QrWatermark {
    * @param string $path Path to the file e.g.:(/var/www/image.png)
    * @return bool
   */
-  public function saveAsImage(string $path): bool {
+  public function saveAsImage(string $path): bool
+  {
     return qrwatermark_generate(
-      $this->_text,
+      $this->text,
       $path,
       $this->_logoPath,
       $this->_imageConfig->color,
@@ -80,7 +89,4 @@ class QrWatermark {
       $this->_imageConfig->pixelSize,
     );
   }
-
 }
-
-?>


### PR DESCRIPTION
> Please note this is untested
> also I have not run the code as I have not loaded the base this uses to create the images
> and as I run 8.4 for dev also uses some new features so bumps the min version so you might not want to merge this.

Changes:

- Applys a PSR12 style to the file (found in phpcs.xml) this is my personal flavor of it
- Adds some ignores if you later turn this into a package to pull with composer (found in .gitattributes)
- uses __construct promotion for public values (found in LogoConfig.php and ImageConfig.php)
- changes the logoConfig function and imageConfig function to support just passing in the builders so you can skip the build call
- removes the ( ) around the new call found in (custom.php)